### PR TITLE
Update Dependencies to IPK versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -249,14 +249,14 @@
 
     <properties>
         <!--Carbon framework version-->
-        <identity.framework.version>5.15.62</identity.framework.version>
-        <carbon.identity.framework.import.version.range>[5.15.0, 6.0.0)</carbon.identity.framework.import.version.range>
+        <identity.framework.version>6.0.0</identity.framework.version>
+        <carbon.identity.framework.import.version.range>[6.0.0, 7.0.0)</carbon.identity.framework.import.version.range>
 
-        <identity.tool.samlsso.validator.import.version.range>[5.3.0, 6.0.0)</identity.tool.samlsso.validator.import.version.range>
+        <identity.tool.samlsso.validator.import.version.range>[6.0.0, 7.0.0)</identity.tool.samlsso.validator.import.version.range>
         <identity.tool.samlsso.validator.export.version>${project.version}</identity.tool.samlsso.validator.export.version>
-        <identity.inbound.auth.saml.version>5.8.14</identity.inbound.auth.saml.version>
-        <identity.inbound.auth.saml.import.version.range>[5.6.13, 6.0.0)</identity.inbound.auth.saml.import.version.range>
-        <identity.carbon.auth.saml2.version>5.4.5</identity.carbon.auth.saml2.version>
+        <identity.inbound.auth.saml.version>6.0.0</identity.inbound.auth.saml.version>
+        <identity.inbound.auth.saml.import.version.range>[6.0.0, 7.0.0)</identity.inbound.auth.saml.import.version.range>
+        <identity.carbon.auth.saml2.version>6.0.0</identity.carbon.auth.saml2.version>
 
         <!-- Carbon kernel version -->
         <carbon.kernel.version>4.6.0</carbon.kernel.version>


### PR DESCRIPTION
The identity components are bumped to major versions created for IPK.

Related issue: https://github.com/wso2-enterprise/identity-k8s-access-runtime/issues/16