### PR TITLE
Remove org.wso2.carbon:org.wso2.carbon.ui.menu.tools from bundling

### DIFF
--- a/features/org.wso2.carbon.identity.tools.saml.validator.ui.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.tools.saml.validator.ui.feature/pom.xml
@@ -76,9 +76,6 @@
                                 <bundleDef>org.wso2.carbon.identity.tool.validator.sso.saml2:org.wso2.carbon.identity.tools.saml.validator.stub
                                 </bundleDef>
                             </bundles>
-                            <importBundles>
-                                <importBundleDef>org.wso2.carbon:org.wso2.carbon.ui.menu.tools</importBundleDef>
-                            </importBundles>
 
                             <importFeatures>
                                 <importFeatureDef>org.wso2.carbon.core:compatible:${carbon.kernel.feature.version}</importFeatureDef>


### PR DESCRIPTION
### Proposed changes in this pull request

Removes `org.wso2.carbon:org.wso2.carbon.ui.menu.tools` from bundling into the IS package

### Related issues
- https://github.com/wso2/product-is/issues/15407
