### PR TITLE
Migrate security-mgt module from framework to its own group.

### DIFF
--- a/components/org.wso2.carbon.identity.tools.saml.validator/pom.xml
+++ b/components/org.wso2.carbon.identity.tools.saml.validator/pom.xml
@@ -64,7 +64,7 @@
             <artifactId>org.wso2.carbon.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <groupId>org.wso2.carbon.security.mgt</groupId>
             <artifactId>org.wso2.carbon.security.mgt</artifactId>
             <exclusions>
                 <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -95,9 +95,9 @@
                 <version>${carbon.kernel.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <groupId>org.wso2.carbon.security.mgt</groupId>
                 <artifactId>org.wso2.carbon.security.mgt</artifactId>
-                <version>${identity.framework.version}</version>
+                <version>${carbon.security.mgt.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon</groupId>
@@ -208,8 +208,8 @@
                 <inherited>true</inherited>
                 <configuration>
                     <encoding>UTF-8</encoding>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -251,6 +251,7 @@
         <!--Carbon framework version-->
         <identity.framework.version>5.25.234</identity.framework.version>
         <carbon.identity.framework.import.version.range>[5.25.234, 7.0.0)</carbon.identity.framework.import.version.range>
+        <carbon.security.mgt.version>1.0.0</carbon.security.mgt.version>
 
         <identity.tool.samlsso.validator.import.version.range>[5.3.0, 6.0.0)</identity.tool.samlsso.validator.import.version.range>
         <identity.tool.samlsso.validator.export.version>${project.version}</identity.tool.samlsso.validator.export.version>


### PR DESCRIPTION
### Proposed changes in this pull request
This PR contains the changes made to migrate the security-mgt component from framework and move it to new carbon.security.mgt group. This is a milestone of the following issue[1].

### Related Issues
- https://github.com/wso2/product-is/issues/16422

### NOTE:
- Product IS PR builder will fail because the the security-mgt component used there is still old version. 

