### PR TITLE
Revert "Migrate security-mgt module from framework to its own group."

### DIFF
--- a/components/org.wso2.carbon.identity.tools.saml.validator/pom.xml
+++ b/components/org.wso2.carbon.identity.tools.saml.validator/pom.xml
@@ -64,7 +64,7 @@
             <artifactId>org.wso2.carbon.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.security.mgt</groupId>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.security.mgt</artifactId>
             <exclusions>
                 <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -95,9 +95,9 @@
                 <version>${carbon.kernel.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wso2.carbon.security.mgt</groupId>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.security.mgt</artifactId>
-                <version>${carbon.security.mgt.version}</version>
+                <version>${identity.framework.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon</groupId>
@@ -208,8 +208,8 @@
                 <inherited>true</inherited>
                 <configuration>
                     <encoding>UTF-8</encoding>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -251,7 +251,6 @@
         <!--Carbon framework version-->
         <identity.framework.version>5.25.234</identity.framework.version>
         <carbon.identity.framework.import.version.range>[5.25.234, 7.0.0)</carbon.identity.framework.import.version.range>
-        <carbon.security.mgt.version>1.0.0</carbon.security.mgt.version>
 
         <identity.tool.samlsso.validator.import.version.range>[5.3.0, 6.0.0)</identity.tool.samlsso.validator.import.version.range>
         <identity.tool.samlsso.validator.export.version>${project.version}</identity.tool.samlsso.validator.export.version>

--- a/pom.xml
+++ b/pom.xml
@@ -249,7 +249,7 @@
 
     <properties>
         <!--Carbon framework version-->
-        <identity.framework.version>5.25.234</identity.framework.version>
+        <identity.framework.version>5.25.305</identity.framework.version>
         <carbon.identity.framework.import.version.range>[5.25.234, 7.0.0)</carbon.identity.framework.import.version.range>
 
         <identity.tool.samlsso.validator.import.version.range>[5.3.0, 6.0.0)</identity.tool.samlsso.validator.import.version.range>


### PR DESCRIPTION
Reverts wso2-extensions/identity-tool-samlsso-validator#43

Related issues:
- https://github.com/wso2/product-is/issues/16422